### PR TITLE
Fixes #1 ldconfig called as a task.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,2 @@
 ---
 # handlers file for nanomsg-role
-- name: ldconfig
-  become: true
-  command: ldconfig

--- a/tasks/debian/install.yml
+++ b/tasks/debian/install.yml
@@ -37,4 +37,7 @@
   command: cmake --build . --target install
   args:
     chdir: "/tmp/{{ nanomsg_role_nanomsg_version_name }}/build"
-  notify: ldconfig
+
+- name: ldconfig
+  become: true
+  command: ldconfig


### PR DESCRIPTION
Remove `ldconfig` handler
Created task using command module to invoke `ldconfig` after `cmake install` of nanomsg libraries.
Removed notify from `cmake install` of nanomsg libraries task